### PR TITLE
Forward CH and PG variables + Skip wget CH probe

### DIFF
--- a/templates/backend-deployment.yaml
+++ b/templates/backend-deployment.yaml
@@ -40,10 +40,18 @@ spec:
               {{- else }}
               value: {{ printf "http://clickhouse-%s-clickhouse.%s.svc.cluster.local:8123" .Release.Name .Release.Namespace | quote }}
               {{- end }}
+            {{- if hasKey .Values.backend.env "SKIP_CLICKHOUSE_WAIT" }}
+            - name: SKIP_CLICKHOUSE_WAIT
+              value: {{ .Values.backend.env.SKIP_CLICKHOUSE_WAIT | quote }}
+            {{- end }}
           command:
             - sh
             - -c
             - |
+              if [ "${SKIP_CLICKHOUSE_WAIT}" = "true" ]; then
+                echo "SKIP_CLICKHOUSE_WAIT=true; skipping ClickHouse readiness check."
+                exit 0
+              fi
               echo "Waiting for ClickHouse to be ready..."
               until wget -q --spider "${CLICKHOUSE_HOST}/ping"; do
                 echo "ClickHouse is not ready yet..."

--- a/templates/backend-deployment.yaml
+++ b/templates/backend-deployment.yaml
@@ -33,24 +33,44 @@ spec:
       initContainers:
         - name: wait-for-clickhouse
           image: busybox:1.35
+          env:
+            - name: CLICKHOUSE_HOST
+              {{- if hasKey .Values.backend.env "CLICKHOUSE_HOST" }}
+              value: {{ .Values.backend.env.CLICKHOUSE_HOST | quote }}
+              {{- else }}
+              value: {{ printf "http://clickhouse-%s-clickhouse.%s.svc.cluster.local:8123" .Release.Name .Release.Namespace | quote }}
+              {{- end }}
           command:
             - sh
             - -c
             - |
               echo "Waiting for ClickHouse to be ready..."
-              until wget -q --spider http://clickhouse-{{ .Release.Name }}-clickhouse.{{ .Release.Namespace }}.svc.cluster.local:8123/ping; do
+              until wget -q --spider "${CLICKHOUSE_HOST}/ping"; do
                 echo "ClickHouse is not ready yet..."
                 sleep 2
               done
               echo "ClickHouse is ready!"
         - name: wait-for-postgres
           image: docker.io/postgres:15-alpine
+          env:
+            - name: PGHOST
+              {{- if hasKey .Values.backend.env "POSTGRES_HOST" }}
+              value: {{ .Values.backend.env.POSTGRES_HOST | quote }}
+              {{- else }}
+              value: {{ printf "%s-postgresql-rw.%s.svc.cluster.local" .Release.Name .Release.Namespace | quote }}
+              {{- end }}
+            - name: PGPORT
+              {{- if hasKey .Values.backend.env "POSTGRES_PORT" }}
+              value: {{ .Values.backend.env.POSTGRES_PORT | quote }}
+              {{- else }}
+              value: "5432"
+              {{- end }}
           command:
             - sh
             - -c
             - |
               echo "Waiting for PostgreSQL to be ready..."
-              until pg_isready -h {{ .Release.Name }}-postgresql-rw.{{ .Release.Namespace }}.svc.cluster.local -p 5432; do
+              until pg_isready; do
                 echo "PostgreSQL is not ready yet..."
                 sleep 2
               done
@@ -101,10 +121,7 @@ spec:
             {{- end }}
             {{- if not (hasKey .Values.backend.env "CLICKHOUSE_USER") }}
             - name: CLICKHOUSE_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Release.Name }}-clickhouse-credentials
-                  key: user
+              value: {{ .Values.clickhouse.auth.username | default "default" | quote }}
             {{- end }}
 
             {{- if not (hasKey .Values.backend.env "CLICKHOUSE_PASSWORD") }}

--- a/values.yaml
+++ b/values.yaml
@@ -65,6 +65,9 @@ backend:
     # POSTGRES_PASSWORD: "use-secret-instead"
     # POSTGRES_PORT: 5432
 
+    ### USE to skip wget probe for externally managed ClickHouse requiring TLS
+    # SKIP_CLICKHOUSE_WAIT: "true"
+
   betterSecret:
     secretName: ""
     authKey: "better-auth-secret"


### PR DESCRIPTION
Upon trying to use this chart with an externally managed Postgres and ClickHouse instance, there were a few setup issues.

Issues:
- ClickHouse and Postgres environment variables were not correctly passed through despite being listed as options.
  - Caveat is that CLICKHOUSE_USER is still not consumed by the underlying rybbit image. If this is fixed in the future then it should be passed through as intended.
  - It forced a connection to the internal clusters even though the appropriate HOST arguments were set. It now uses the appropriate environment variables when trying to connect.
- `wget` ClickHouse probe was always ran, but for instances requiring TLS it would fail causing the deployment to hang.
  - To resolve, added an optional `SKIP_CLICKHOUSE_WAIT` environment variable. Defaults to probing to keep existing behaviour.