### PR TITLE
fix: ClickHouse OOM crash loop from trace-level text_log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-08-04
+
+### Fixed
+- **ClickHouse OOM crash loop:** `system.text_log` was enabled at `trace` level (ClickHouse default), persisting every debug message to disk. During merge-heavy periods this grew `system.text_log` to ~16 GiB with hundreds of unmerged parts, pinning the pod at its 1-core CPU limit and OOM-killing it every ~20 minutes (100+ restarts). The chart now overrides `text_log.level` to `error`.
+
+### Changed
+- Bump ClickHouse resource limits from `1000m/2Gi` to `2000m/4Gi` — the default was undersized for the merge machinery + internal log tables, leaving zero memory headroom (the server pinned its whole budget, and even `TRUNCATE` on system tables was rejected by the OvercommitTracker).
+
 ## [1.0.0] - 2026-08-03
 
 ### Added

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rybbit
 description: A Helm chart for Rybbit self-hosted analytics
 type: application
-version: 1.0.0
+version: 1.1.0
 appVersion: "2.8.0"
 kubeVersion: ">=1.19.0-0"
 maintainers:

--- a/templates/clickhouse-chi.yaml
+++ b/templates/clickhouse-chi.yaml
@@ -97,6 +97,9 @@ spec:
     files:
       config.d/extra_config.xml: |
         <clickhouse>
+          <text_log>
+            <level>error</level>
+          </text_log>
         </clickhouse>
       users.d/extra_users.xml: |
         <clickhouse>

--- a/values.yaml
+++ b/values.yaml
@@ -236,8 +236,8 @@ clickhouse:
         memory: "600Mi"
         cpu: "100m"
       limits:
-        memory: "2Gi"
-        cpu: "1000m"
+        memory: "4Gi"
+        cpu: "2000m"
   keeper:
     enabled: true
     image: docker.io/altinity/clickhouse-keeper:25.3.6.10034.altinitystable


### PR DESCRIPTION
## Problem

The ClickHouse pod in production (ton-cluster, namespace `rybbit`) has been crash-looping: **100+ restarts in 35h**, all `OOMKilled`, pinned at **999m/1000m CPU**.

Root cause chain:

1. `system.text_log` runs at **trace** level (ClickHouse default) — every debug message is persisted to disk.
2. During merge-heavy periods this grew `system.text_log` to **16.69 GiB / 328M rows / 739 parts** (plus `metric_log` 592 parts, `trace_log`, `asynchronous_metric_log`... ≈ 1,667 total parts vs a healthy ~tens).
3. The merge backlog exceeded what 1 core could drain → merge storm → more log volume → more parts (self-amplifying).
4. Merges + flush buffers pushed RSS past the **2Gi** limit → OOMKill → restart → backlog resumes → **OOM every ~20 min**.

Evidence: no user queries in `system.processes` (CPU was 100% background merge machinery), server RSS pinned at the whole 1.8 GiB budget (2Gi × 0.9), even `TRUNCATE TABLE system.*` was rejected by the OvercommitTracker.

## Fix

- **`templates/clickhouse-chi.yaml`** — override `text_log.level` to `error` in the CHI extra config, so the internal log table stops growing without bound.
- **`values.yaml`** — bump ClickHouse limits `1000m/2Gi` → `2000m/4Gi`: the default left zero memory headroom (the server pinned its entire budget and rejected every query as an overcommit victim). 4Gi is a modest default for an analytics workload; overridable per deployment via `clickhouse.clickhouse.resources`.

## Verification

- `helm lint` passes; `helm template` renders the `text_log` override correctly.
- Operational cleanup on the cluster already done (truncate of the accumulated system log tables + merge backlog drained); the new limits let the remaining backlog drain without OOM.

Closes the production crash loop observed on ton-cluster.